### PR TITLE
Add team winning percentages as new column in CSV files

### DIFF
--- a/data/load_data.py
+++ b/data/load_data.py
@@ -41,6 +41,8 @@ def download_mvp_stats():
                 # In absence of appending MVP votes, the same columns are filled with NaN for the current season
                 df.loc[:, mvp_votes.RELEVANT_COL_NAMES] = float("NaN")
 
+            df = get_team_record_df(df, season)
+
             df.to_csv(complete_name, index=False)
 
     print("Completed load MVP stats.")
@@ -79,6 +81,19 @@ def get_appended_votes_df(stats_df, season):
     df_with_votes.loc[:, mvp_votes.RELEVANT_COL_NAMES] = df_with_votes.loc[:, mvp_votes.RELEVANT_COL_NAMES].fillna(value=0)
 
     return df_with_votes
+
+def get_team_record_df(stats_df, season):
+    """
+    Returns a DataFrame object identical to the one passed as an argument, but with the record of the team each player played for in the passed season appended to the DataFrame.
+
+    :param stats_df: A DataFrame object containing NBA season average statistics.
+    :param season: An integer value representing the season from which MVP voting should be retrieved. For instance, an inputted season value of 2019 returns the voting record from the 2019-2020 season. 
+    :return: An identical DataFrame object to the one passed, but with team winning percentages for the passed season appended.
+    """
+    record = team_records.get_team_record_map(season)
+    record_df = pd.DataFrame.from_dict(record, orient="index", columns=["winning_perc"])
+
+    return pd.merge(stats_df, record_df, how="left", left_on="team_id", right_index=True)
 
 def drop_duplicate_cols(stats_df):
     """

--- a/data/scraping/basketball_reference/team_records.py
+++ b/data/scraping/basketball_reference/team_records.py
@@ -23,7 +23,7 @@ def get_team_record_map(season):
 
     soup = BeautifulSoup(page.content, 'html.parser')
 
-    if season >= 2015:
+    if season >= 2016:
         east_table = soup.find(id='confs_standings_E')
         west_table = soup.find(id='confs_standings_W')
     else:

--- a/data/scraping/basketball_reference/team_records.py
+++ b/data/scraping/basketball_reference/team_records.py
@@ -23,8 +23,12 @@ def get_team_record_map(season):
 
     soup = BeautifulSoup(page.content, 'html.parser')
 
-    east_table = soup.find(id='confs_standings_E')
-    west_table = soup.find(id='confs_standings_W')
+    if season >= 2015:
+        east_table = soup.find(id='confs_standings_E')
+        west_table = soup.find(id='confs_standings_W')
+    else:
+        east_table = soup.find(id='divs_standings_E')
+        west_table = soup.find(id='divs_standings_W')
 
     # tuple holding both table objects for ease of further scraping
     record_tables = (east_table, west_table)

--- a/data/scraping/basketball_reference/team_records.py
+++ b/data/scraping/basketball_reference/team_records.py
@@ -44,7 +44,10 @@ def get_team_record_map(season):
             td = valid_tds[i]
             th = valid_ths[i]
 
-            record_map[th.get_text().replace("*", "")] = td.get_text()
+            team_id = __get_team_id(th)
+            team_record = float(td.get_text())
+
+            record_map[team_id] = team_record
 
     return record_map
 
@@ -77,3 +80,15 @@ def __get_relevant_tds(tds):
             valid_tds.append(td)
 
     return valid_tds
+
+def __get_team_id(th):
+    """
+    Returns the three-letter team ID from the passed th tag.
+
+    :th: A th tag holding the name of an NBA team.
+    :return: The three-letter team ID that basketball-reference.com uses to identify the team.
+    """
+    url = str(th.find("a").get("href"))
+    team_id = url.replace("/teams/", "").split("/", 1)[0]     # Taking the three-letter team ID from the link to the team's individual page for the season
+
+    return team_id


### PR DESCRIPTION
Using an already existing file that scrapes basketball-reference.com for team records by season, `team_records.py`, team winning percentages are merged onto the season average data via each player's team ID. Closes #8.