### PR TITLE
 Join league leaders data with existing data in CSV files

### DIFF
--- a/data/scraping/basketball_reference/bball_ref_utils.py
+++ b/data/scraping/basketball_reference/bball_ref_utils.py
@@ -61,3 +61,16 @@ def check_status_code(response, season):
         else:
             exception_message = "%d Error: %s" % (response.status_code, response.reason)
             raise Exception(exception_message)
+
+def get_player_id_from_url(url):
+    """
+    Retrieves and returns the player id from the URL to the player's profile page.
+
+    :param url: A URL linking to the profile page of a player (e.g., https://www.basketball-reference.com/players/b/bealbr01.html).
+    :return: The id of the player who is represented on the profile page linked.
+    """
+    # player id held between the last forward slash and the extention
+    left_index = url.rfind("/") + 1
+    right_index = url.index(".html")
+
+    return url[left_index: right_index]

--- a/data/scraping/basketball_reference/league_leaders.py
+++ b/data/scraping/basketball_reference/league_leaders.py
@@ -5,3 +5,23 @@ Retrieves league leader data for a given season from basketball-reference.com
 import pandas as pd
 
 from .bball_ref_utils import *
+
+BASE_URL = "https://www.basketball-reference.com/leagues/"
+
+def get_full_league_leaders(season, fields):
+    """
+    Returns a list containing information about the league leaders for the passed season.
+        
+    :param season: The season from which league leaders statistics will be returned.
+    :param fields: A list of strings containing the fields from which league leaders should be retrieved (e.g., "pts_per_g").
+    :return: A list of dictionaries holding the league leaders of all the players in the passed season.
+    """
+    season = convert_bdl_season_to_bball_ref(season)
+
+    url = BASE_URL + f"NBA_{season}_leaders.html"
+
+    page = requests.get(url)
+
+    check_status_code(page, season)
+
+    soup = BeautifulSoup(page.content, 'html.parser')

--- a/data/scraping/basketball_reference/league_leaders.py
+++ b/data/scraping/basketball_reference/league_leaders.py
@@ -25,3 +25,27 @@ def get_full_league_leaders(season, fields):
     check_status_code(page, season)
 
     soup = BeautifulSoup(page.content, 'html.parser')
+
+def get_league_leader(soup_page, field):
+    """
+    Given a passed field and BeautifulSoup object of the league leaders page, returns the information about the first place player in that field in a dictionary.
+
+    :param soup_page: A BeautifulSoup object of the league leaders page.
+    :param field: The field from which the league leader will be returned. 
+    :return: A dictionary containing the id of the player leading the league in the given category and the name of the category they are leading the league in.
+    """
+    leaders_div = soup_page.find(id=f"leaders_{field}")     # The div containing the information of the league leaders of a certain field.
+
+    field_name = leaders_div.get("id")
+    index = field_name.index("leaders_") + len("leaders_")
+    field_name = field_name[index:]
+
+    table = leaders_div.find("table", "columns")    # this table contains the 20 leaders in the given field
+    first_place_tr = table.find("tr", "first_place")
+
+    league_leader = {
+        "player_id": get_player_id_from_url(first_place_tr.find("td", "who").find("a").get("href")),
+        "field": field_name
+    }
+
+    return league_leader

--- a/data/scraping/basketball_reference/league_leaders.py
+++ b/data/scraping/basketball_reference/league_leaders.py
@@ -10,11 +10,11 @@ BASE_URL = "https://www.basketball-reference.com/leagues/"
 
 def get_full_league_leaders(season, fields):
     """
-    Returns a list containing information about the league leaders for the passed season.
+    Returns a list containing information about the league leaders for the passed fields in the specified season.
         
     :param season: The season from which league leaders statistics will be returned.
     :param fields: A list of strings containing the fields from which league leaders should be retrieved (e.g., "pts_per_g").
-    :return: A list of dictionaries holding the league leaders of all the players in the passed season.
+    :return: A list holding the league leaders of all the passed fields in the specified season.
     """
     season = convert_bdl_season_to_bball_ref(season)
 
@@ -57,3 +57,15 @@ def get_league_leader(soup_page, field):
     }
 
     return league_leader
+
+def get_full_league_leaders_df(season, fields):
+    """
+    Returns a DataFrame object containing information about the league leaders for the passed fields in the specified season.
+        
+    :param season: The season from which league leaders statistics will be returned.
+    :param fields: A list of strings containing the fields from which league leaders should be retrieved (e.g., "pts_per_g").
+    :return: A DataFrame object holding the league leaders of all the passed fields in the specified season.
+    """
+    league_leaders_list = get_full_league_leaders(season, fields)
+    
+    return pd.DataFrame.from_dict(league_leaders_list)

--- a/data/scraping/basketball_reference/league_leaders.py
+++ b/data/scraping/basketball_reference/league_leaders.py
@@ -25,6 +25,14 @@ def get_full_league_leaders(season, fields):
     check_status_code(page, season)
 
     soup = BeautifulSoup(page.content, 'html.parser')
+    
+    league_leaders = []
+
+    for field in fields:
+        field_leader = get_league_leader(soup, field)
+        league_leaders.append(field_leader)
+
+    return league_leaders
 
 def get_league_leader(soup_page, field):
     """

--- a/data/scraping/basketball_reference/league_leaders.py
+++ b/data/scraping/basketball_reference/league_leaders.py
@@ -1,0 +1,7 @@
+"""
+Retrieves league leader data for a given season from basketball-reference.com
+"""
+
+import pandas as pd
+
+from .bball_ref_utils import *


### PR DESCRIPTION
This pull request introduces new binary fields corresponding to whether or not each player led the league in the category specified by the column. For instance, the `leader_pts_per_game` column will have a value of 0 for all players that did not lead the league in points per game in the season that their CSV file represents, and will have a value of 1 for the player that did lead the league in that category. 

While this way of distinguishing league leaders is not optimal for analysis, it provides lots of potential for feature engineering prior to using the data in a predictive model.

Resolves #12 